### PR TITLE
Corrige cache de traduções por empresa

### DIFF
--- a/src/tests/react/utils/translate.test.mjs
+++ b/src/tests/react/utils/translate.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import Translate from '../../../utils/translate.js';
+
+const installLocalStorage = () => {
+  const storage = {};
+
+  global.localStorage = {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(storage, key)
+        ? storage[key]
+        : null;
+    },
+    setItem(key, value) {
+      storage[key] = String(value);
+    },
+    removeItem(key) {
+      delete storage[key];
+    },
+  };
+
+  localStorage.setItem('config', JSON.stringify({language: 'pt-br'}));
+  localStorage.setItem('translates', JSON.stringify({}));
+};
+
+test('prefers the current company translation and falls back to the default company', () => {
+  installLocalStorage();
+
+  const translate = new Translate(
+    [{id: 1}, {id: 5}],
+    {id: 1},
+    {id: 5},
+    ['orders'],
+    {},
+  );
+
+  translate.findMessage('orders', 'label', 'save', 'Salvar', 1);
+  translate.findMessage('orders', 'label', 'save', 'Save for ASC', 5);
+  translate.persist();
+
+  assert.equal(translate.t('orders', 'label', 'save'), 'Save for ASC');
+
+  const fallbackTranslate = new Translate(
+    [{id: 1}, {id: 5}],
+    {id: 1},
+    {id: 9},
+    ['orders'],
+    {},
+  );
+
+  assert.equal(fallbackTranslate.t('orders', 'label', 'save'), 'Salvar');
+});
+
+test('loads each requested store for every linked company once', async () => {
+  installLocalStorage();
+
+  const calls = [];
+  const translate = new Translate(
+    [{id: 1}, {id: 5}],
+    {id: 1},
+    {id: 5},
+    ['orders', 'crm'],
+    {
+      getItems: async params => {
+        calls.push(params);
+        return [];
+      },
+      addToQueue: () => {},
+      initQueue: () => {},
+    },
+  );
+
+  await translate.discoveryAll();
+
+  assert.deepEqual(calls, [
+    {store: 'orders', 'language.language': 'pt-br', people: '/people/1', page: 1},
+    {store: 'orders', 'language.language': 'pt-br', people: '/people/5', page: 1},
+    {store: 'crm', 'language.language': 'pt-br', people: '/people/1', page: 1},
+    {store: 'crm', 'language.language': 'pt-br', people: '/people/5', page: 1},
+  ]);
+});

--- a/src/utils/translate.js
+++ b/src/utils/translate.js
@@ -12,6 +12,117 @@ export default class Translate {
     this.stores = stores;
   }
 
+  getLanguageBucket(createIfMissing = false) {
+    if (!this.translates[this.language] && createIfMissing) {
+      this.translates[this.language] = {};
+    }
+
+    return this.translates[this.language] || null;
+  }
+
+  getCompanyBucket(companyId, createIfMissing = false) {
+    const normalizedCompanyId = this.normalizeId(companyId);
+    if (!normalizedCompanyId) return null;
+
+    const languageBucket = this.getLanguageBucket(createIfMissing);
+    if (!languageBucket) return null;
+
+    if (!languageBucket.companies && createIfMissing) {
+      languageBucket.companies = {};
+    }
+
+    if (
+      createIfMissing &&
+      languageBucket.companies &&
+      !languageBucket.companies[normalizedCompanyId]
+    ) {
+      languageBucket.companies[normalizedCompanyId] = {};
+    }
+
+    return languageBucket.companies?.[normalizedCompanyId] || null;
+  }
+
+  getStoreBucket(companyId, store, createIfMissing = false) {
+    if (!store) return null;
+
+    if (companyId) {
+      const companyBucket = this.getCompanyBucket(companyId, createIfMissing);
+      if (!companyBucket) return null;
+
+      if (createIfMissing && !companyBucket[store]) {
+        companyBucket[store] = {};
+      }
+
+      return companyBucket[store] || null;
+    }
+
+    const languageBucket = this.getLanguageBucket(createIfMissing);
+    if (!languageBucket) return null;
+
+    if (createIfMissing && !languageBucket[store]) {
+      languageBucket[store] = {};
+    }
+
+    return languageBucket[store] || null;
+  }
+
+  normalizeId(value) {
+    if (value == null) return null;
+
+    const match = String(value).match(/\d+/);
+    return match?.[0] || null;
+  }
+
+  getCompaniesToCache() {
+    const companies = Array.isArray(this.companies) ? this.companies : [];
+    const candidates = [
+      this.defaultCompany,
+      this.currentCompany,
+      ...companies,
+    ].filter((company) => company?.id);
+
+    const unique = [];
+    const seen = new Set();
+
+    candidates.forEach((company) => {
+      const companyId = this.normalizeId(company.id);
+      if (!companyId || seen.has(companyId)) return;
+
+      seen.add(companyId);
+      unique.push(company);
+    });
+
+    return unique;
+  }
+
+  getStoreList() {
+    if (Array.isArray(this.stores)) {
+      return this.stores.filter(Boolean);
+    }
+
+    return this.stores ? [this.stores] : [];
+  }
+
+  getMessageFromBuckets(store, type, key) {
+    const companyIds = [
+      this.currentCompany?.id,
+      this.defaultCompany?.id,
+    ]
+      .map((value) => this.normalizeId(value))
+      .filter(Boolean);
+
+    for (const companyId of companyIds) {
+      const companyMessage =
+        this.getStoreBucket(companyId, store)?.[type]?.[key];
+
+      if (companyMessage) {
+        return companyMessage;
+      }
+    }
+
+    return this.getStoreBucket(null, store)?.[type]?.[key];
+  }
+
   persistMissingTranslate(store, type, key, translate) {
     if (!store || !type || !key || !this.defaultCompany?.id) return;
 
@@ -42,9 +153,7 @@ export default class Translate {
   }
 
   t(store, type, key) {
-
-    let translate =
-      this.translates?.[this.language]?.[store]?.[type]?.[key];
+    let translate = this.getMessageFromBuckets(store, type, key);
 
     if (!translate) {
       translate = this.formatMessage(key);
@@ -65,19 +174,27 @@ export default class Translate {
   }
 
   async discoveryAll() {
-    if (!this.translates || !this.translates[this.language])
-      await this.discoveryStoreTranslate(this.stores);
+    for (const store of this.getStoreList()) {
+      await this.discoveryStoreTranslate(store);
+    }
 
     return this.translates;
   }
 
   async discoveryStoreTranslate(store) {
-    if (!this.translates[this.language]) this.translates[this.language] = {};
+    if (!store) return this.translates;
 
-    if (this.translates[this.language][store]) return this.translates;
+    const companies = this.getCompaniesToCache();
+    const pendingCompanies = companies.filter((company) => {
+      const companyStoreBucket = this.getStoreBucket(company.id, store);
+      return !companyStoreBucket;
+    });
 
-    await this.fetchTranslates(store, this.defaultCompany);
-    await this.fetchTranslates(store, this.currentCompany);
+    if (pendingCompanies.length === 0) return this.translates;
+
+    for (const company of pendingCompanies) {
+      await this.fetchTranslates(store, company);
+    }
 
     return this.translates;
   }
@@ -111,37 +228,24 @@ export default class Translate {
       page += 1;
     }
 
-    const currentTranslates = this.translates;
+    const companyId = this.normalizeId(company?.id);
+    const storeBucket = this.getStoreBucket(companyId, store, true);
 
-    if (company === this.defaultCompany) {
-      storeTranslates.forEach((element) => {
-        this.findMessage(
-          element.store,
-          element.type,
-          element.key,
-          element.translate || this.formatMessage(element.key)
-        );
-      });
-    } else if (company === this.currentCompany) {
-      storeTranslates.forEach((element) => {
-        const existingMessage =
-          currentTranslates?.[this.language]?.[store]?.[element.type]?.[
-          element.key
-          ];
-
-        const newMessage =
-          element.translate || this.formatMessage(element.key);
-
-        if (existingMessage !== newMessage) {
-          this.findMessage(
-            element.store,
-            element.type,
-            element.key,
-            newMessage
-          );
-        }
+    if (storeBucket) {
+      Object.keys(storeBucket).forEach((type) => {
+        delete storeBucket[type];
       });
     }
+
+    storeTranslates.forEach((element) => {
+      this.findMessage(
+        element.store,
+        element.type,
+        element.key,
+        element.translate || this.formatMessage(element.key),
+        companyId
+      );
+    });
 
     this.persist();
   }
@@ -150,22 +254,20 @@ export default class Translate {
     localStorage.setItem("translates", JSON.stringify(this.translates));
   }
 
-  findMessage(store, type, key, message) {
-    if (!this.translates[this.language]) this.translates[this.language] = {};
+  findMessage(store, type, key, message, companyId = null) {
+    const storeBucket = this.getStoreBucket(companyId, store, true);
+    if (!storeBucket) {
+      return this.formatMessage(key);
+    }
 
-    if (!this.translates[this.language][store])
-      this.translates[this.language][store] = {};
-
-    if (!this.translates[this.language][store][type])
-      this.translates[this.language][store][type] = {};
+    if (!storeBucket[type]) {
+      storeBucket[type] = {};
+    }
 
     if (message !== null)
-      this.translates[this.language][store][type][key] = message;
+      storeBucket[type][key] = message;
 
-    return (
-      this.translates[this.language][store][type][key] ||
-      this.formatMessage(key)
-    );
+    return storeBucket[type][key] || this.formatMessage(key);
   }
 
   formatMessage(key) {


### PR DESCRIPTION
Atende a issue `ControleOnline/app-community#62`.

## O que mudou
- separa o cache local de traduções por empresa, evitando que uma empresa sobrescreva a outra no mesmo idioma
- corrige a descoberta inicial para carregar cada store individualmente, em vez de tratar a lista inteira como uma chave única
- passa a baixar as traduções das empresas vinculadas ao usuário para reaproveitar o cache ao trocar de empresa
- mantém fallback da empresa atual para a empresa padrão quando não houver sobrescrita local
- adiciona teste automatizado focado no cache por empresa e na descoberta por store

## Impacto entre projetos
- `app-community`: recebe o comportamento corrigido via `ui-common`
- `api-community`: sem mudanças de contrato ou endpoint
- `api-whatsapp`: sem impacto identificado

## Validação
- `node --test src/tests/react/utils/translate.test.mjs`

## Observação
- este repositório não expõe branch `dev`, então o PR foi aberto contra `master` para manter o diff isolado e revisável.