### PR TITLE
Improve CSV import feedback and refresh flow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,19 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - run: npm run test:imports-status

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "src/vue/index.js",
   "scripts": {
     "test": "npm run test:imports-status",
-    "test:imports-status": "node --test src/tests/react/utils/importStatus.test.js"
+    "test:imports-status": "mkdir -p node_modules/@controleonline && ln -sfn ../.. node_modules/@controleonline/ui-common && node --test src/tests/react/utils/importStatus.test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "ControleOnline Common Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "npm run test:imports-status",
+    "test:imports-status": "node --test src/tests/react/utils/importStatus.test.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ControleOnline/ui-common.git"

--- a/src/react/pages/Imports.js
+++ b/src/react/pages/Imports.js
@@ -17,80 +17,12 @@ import AddImportModal from '../components/AddImportModal';
 import { Directory, File } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import styles from './Imports.styles';
-
-const normalizeImportStatus = value =>
-    String(value || '')
-        .trim()
-        .toLowerCase();
-
-const getImportStatusMeta = item => {
-    const rawStatus =
-        item?.status?.realStatus ||
-        item?.status?.status ||
-        item?.status?.name ||
-        '';
-    const normalizedStatus = normalizeImportStatus(rawStatus);
-
-    const processingStatuses = ['pending', 'processing', 'queued', 'uploading', 'uploaded'];
-    const errorStatuses = ['error', 'failed', 'failure', 'invalid'];
-    const successStatuses = ['done', 'success', 'completed', 'processed', 'finished'];
-
-    if (processingStatuses.includes(normalizedStatus)) {
-        return {
-            isProcessing: true,
-            isError: false,
-            labelKey: 'processing',
-            rawStatus,
-            backgroundColor: '#FEF3C7',
-            textColor: '#B45309',
-        };
-    }
-
-    if (errorStatuses.includes(normalizedStatus)) {
-        return {
-            isProcessing: false,
-            isError: true,
-            labelKey: 'error',
-            rawStatus,
-            backgroundColor: '#FEE2E2',
-            textColor: '#B91C1C',
-        };
-    }
-
-    if (successStatuses.includes(normalizedStatus)) {
-        return {
-            isProcessing: false,
-            isError: false,
-            labelKey: 'done',
-            rawStatus,
-            backgroundColor: '#DCFCE7',
-            textColor: '#15803D',
-        };
-    }
-
-    return {
-        isProcessing: false,
-        isError: false,
-        labelKey: 'fallback',
-        rawStatus,
-        backgroundColor: '#E2E8F0',
-        textColor: '#475569',
-    };
-};
-
-const getImportErrorDetail = item => {
-    const candidates = [
-        item?.error,
-        item?.errorMessage,
-        item?.status?.message,
-        item?.status?.description,
-        item?.status?.detail,
-        item?.detail,
-        item?.message,
-    ];
-
-    return candidates.find(candidate => String(candidate || '').trim()) || '';
-};
+const {
+    getImportErrorDetail,
+    getImportStatusMeta,
+    resolveImportLabels,
+    resolveImportStatusLabel: resolveImportStatusLabelValue,
+} = require('../utils/importStatus');
 
 const formatDate = (dateString) => {
     const d = new Date(dateString);
@@ -105,14 +37,14 @@ const Imports = ({ context = {}, onClose }) => {
     const importType = context.context;
     const title = context.title;
     const searchPlaceholder = context.searchPlaceholder;
-    const refreshLabel = global.t?.t('imports', 'button', 'refresh') || 'Atualizar';
-    const processingLabel = global.t?.t('imports', 'status', 'processing') || 'Processando';
-    const errorLabel = global.t?.t('imports', 'status', 'error') || 'Erro';
-    const doneLabel = global.t?.t('imports', 'status', 'done') || 'Concluido';
-    const noStatusLabel = global.t?.t('imports', 'status', 'no_status') || 'Sem status';
-    const processingHelpLabel =
-        global.t?.t('imports', 'message', 'processing_after_upload') ||
-        'Importacao enviada e aguardando processamento.';
+    const {
+        refreshLabel,
+        processingLabel,
+        errorLabel,
+        doneLabel,
+        noStatusLabel,
+        processingHelpLabel,
+    } = resolveImportLabels(global.t?.t);
 
     const navigation = useNavigation();
 
@@ -193,10 +125,12 @@ const Imports = ({ context = {}, onClose }) => {
 
     const resolveImportStatusLabel = useCallback(
         statusMeta => {
-            if (statusMeta.labelKey === 'processing') return processingLabel;
-            if (statusMeta.labelKey === 'error') return errorLabel;
-            if (statusMeta.labelKey === 'done') return doneLabel;
-            return statusMeta.rawStatus || noStatusLabel;
+            return resolveImportStatusLabelValue(statusMeta, {
+                processingLabel,
+                errorLabel,
+                doneLabel,
+                noStatusLabel,
+            });
         },
         [doneLabel, errorLabel, noStatusLabel, processingLabel],
     );

--- a/src/react/pages/Imports.js
+++ b/src/react/pages/Imports.js
@@ -22,7 +22,7 @@ const {
     getImportStatusMeta,
     resolveImportLabels,
     resolveImportStatusLabel: resolveImportStatusLabelValue,
-} = require('../utils/importStatus');
+} = require('@controleonline/ui-common/src/react/utils/importStatus');
 
 const formatDate = (dateString) => {
     const d = new Date(dateString);

--- a/src/react/pages/Imports.js
+++ b/src/react/pages/Imports.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useLayoutEffect } from 'react';
+import React, { useCallback, useState, useEffect, useLayoutEffect, useMemo } from 'react';
 import {
     Text,
     View,
@@ -18,6 +18,80 @@ import { Directory, File } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import styles from './Imports.styles';
 
+const normalizeImportStatus = value =>
+    String(value || '')
+        .trim()
+        .toLowerCase();
+
+const getImportStatusMeta = item => {
+    const rawStatus =
+        item?.status?.realStatus ||
+        item?.status?.status ||
+        item?.status?.name ||
+        '';
+    const normalizedStatus = normalizeImportStatus(rawStatus);
+
+    const processingStatuses = ['pending', 'processing', 'queued', 'uploading', 'uploaded'];
+    const errorStatuses = ['error', 'failed', 'failure', 'invalid'];
+    const successStatuses = ['done', 'success', 'completed', 'processed', 'finished'];
+
+    if (processingStatuses.includes(normalizedStatus)) {
+        return {
+            isProcessing: true,
+            isError: false,
+            labelKey: 'processing',
+            rawStatus,
+            backgroundColor: '#FEF3C7',
+            textColor: '#B45309',
+        };
+    }
+
+    if (errorStatuses.includes(normalizedStatus)) {
+        return {
+            isProcessing: false,
+            isError: true,
+            labelKey: 'error',
+            rawStatus,
+            backgroundColor: '#FEE2E2',
+            textColor: '#B91C1C',
+        };
+    }
+
+    if (successStatuses.includes(normalizedStatus)) {
+        return {
+            isProcessing: false,
+            isError: false,
+            labelKey: 'done',
+            rawStatus,
+            backgroundColor: '#DCFCE7',
+            textColor: '#15803D',
+        };
+    }
+
+    return {
+        isProcessing: false,
+        isError: false,
+        labelKey: 'fallback',
+        rawStatus,
+        backgroundColor: '#E2E8F0',
+        textColor: '#475569',
+    };
+};
+
+const getImportErrorDetail = item => {
+    const candidates = [
+        item?.error,
+        item?.errorMessage,
+        item?.status?.message,
+        item?.status?.description,
+        item?.status?.detail,
+        item?.detail,
+        item?.message,
+    ];
+
+    return candidates.find(candidate => String(candidate || '').trim()) || '';
+};
+
 const formatDate = (dateString) => {
     const d = new Date(dateString);
     return d.toLocaleString(); // Formato local legível
@@ -31,6 +105,14 @@ const Imports = ({ context = {}, onClose }) => {
     const importType = context.context;
     const title = context.title;
     const searchPlaceholder = context.searchPlaceholder;
+    const refreshLabel = global.t?.t('imports', 'button', 'refresh') || 'Atualizar';
+    const processingLabel = global.t?.t('imports', 'status', 'processing') || 'Processando';
+    const errorLabel = global.t?.t('imports', 'status', 'error') || 'Erro';
+    const doneLabel = global.t?.t('imports', 'status', 'done') || 'Concluido';
+    const noStatusLabel = global.t?.t('imports', 'status', 'no_status') || 'Sem status';
+    const processingHelpLabel =
+        global.t?.t('imports', 'message', 'processing_after_upload') ||
+        'Importacao enviada e aguardando processamento.';
 
     const navigation = useNavigation();
 
@@ -64,9 +146,9 @@ const Imports = ({ context = {}, onClose }) => {
                 params.name = String(query ?? searchQuery).trim();
             }
 
-            actions.getItems(params);
+            return actions.getItems(params);
         },
-        [currentPage, itemsPerPage, searchQuery, importType],
+        [actions, currentCompany, currentPage, itemsPerPage, searchQuery, importType],
     );
 
     useLayoutEffect(() => {
@@ -78,7 +160,7 @@ const Imports = ({ context = {}, onClose }) => {
     useFocusEffect(
         useCallback(() => {
             fetchImports(searchQuery, currentPage);
-        }, [currentPage, itemsPerPage, searchQuery, importType]),
+        }, [currentPage, fetchImports, searchQuery]),
     );
 
     useEffect(() => {
@@ -104,14 +186,49 @@ const Imports = ({ context = {}, onClose }) => {
         return () => clearTimeout(t);
     }, [searchText]);
 
-    const onRefresh = useCallback(() => {
+    const hasProcessingImports = useMemo(
+        () => allImports.some(item => getImportStatusMeta(item).isProcessing),
+        [allImports],
+    );
+
+    const resolveImportStatusLabel = useCallback(
+        statusMeta => {
+            if (statusMeta.labelKey === 'processing') return processingLabel;
+            if (statusMeta.labelKey === 'error') return errorLabel;
+            if (statusMeta.labelKey === 'done') return doneLabel;
+            return statusMeta.rawStatus || noStatusLabel;
+        },
+        [doneLabel, errorLabel, noStatusLabel, processingLabel],
+    );
+
+    useEffect(() => {
+        if (!hasProcessingImports) {
+            return undefined;
+        }
+
+        const intervalId = setInterval(() => {
+            setCurrentPage(1);
+            fetchImports(searchQuery, 1);
+        }, 15000);
+
+        return () => clearInterval(intervalId);
+    }, [fetchImports, hasProcessingImports, searchQuery]);
+
+    const onRefresh = useCallback(async () => {
         setRefreshing(true);
-        fetchImports(searchQuery, 1);
-        setCurrentPage(1);
-        setRefreshing(false);
+        try {
+            setCurrentPage(1);
+            await fetchImports(searchQuery, 1);
+        } finally {
+            setRefreshing(false);
+        }
     }, [fetchImports, searchQuery]);
 
-    const renderImportCard = ({ item }) => (
+    const renderImportCard = ({ item }) => {
+        const statusMeta = getImportStatusMeta(item);
+        const errorDetail = statusMeta.isError ? getImportErrorDetail(item) : '';
+
+        return (
         <TouchableOpacity style={styles.card} activeOpacity={0.8}>
             <View style={styles.cardHeader}>
                 <View style={styles.avatar}>
@@ -138,15 +255,45 @@ const Imports = ({ context = {}, onClose }) => {
                     <Text style={styles.infoText}>{formatDate(item.uploadDate)}</Text>
                 </View>
 
-                {item.status?.status && (
+                {(item.status?.status || statusMeta.rawStatus || statusMeta.labelKey) && (
                     <View style={styles.infoRow}>
                         <Icon name="info-circle" size={16} color={colors.primary} />
-                        <Text style={styles.infoText}>{item.status.status}</Text>
+                        <View style={styles.statusContent}>
+                            <View
+                                style={[
+                                    styles.statusBadge,
+                                    {
+                                        backgroundColor: statusMeta.backgroundColor,
+                                    },
+                                ]}>
+                                <Text
+                                    style={[
+                                        styles.statusBadgeText,
+                                        { color: statusMeta.textColor },
+                                    ]}>
+                                    {resolveImportStatusLabel(statusMeta)}
+                                </Text>
+                            </View>
+
+                            {statusMeta.isProcessing && (
+                                <Text style={styles.statusHelperText}>
+                                    {processingHelpLabel}
+                                </Text>
+                            )}
+                        </View>
                     </View>
                 )}
+
+                {errorDetail ? (
+                    <View style={styles.infoRow}>
+                        <Icon name="exclamation-circle" size={16} color="#DC2626" />
+                        <Text style={styles.errorText}>{errorDetail}</Text>
+                    </View>
+                ) : null}
             </View>
         </TouchableOpacity>
-    );
+        );
+    };
 
     const downloadTemplate = async () => {
         try {
@@ -206,10 +353,24 @@ const Imports = ({ context = {}, onClose }) => {
 
             <View style={styles.subHeader}>
                 <View style={styles.topRow}>
-                    <TouchableOpacity style={styles.downloadButton} onPress={downloadTemplate}>
-                        <IconAdd name="download" size={20} color="#fff" />
-                        <Text style={styles.downloadText}>Baixar Modelo</Text>
-                    </TouchableOpacity>
+                    <View style={styles.topRowActions}>
+                        <TouchableOpacity style={styles.downloadButton} onPress={downloadTemplate}>
+                            <IconAdd name="download" size={20} color="#fff" />
+                            <Text style={styles.downloadText}>Baixar Modelo</Text>
+                        </TouchableOpacity>
+
+                        <TouchableOpacity style={styles.refreshButton} onPress={onRefresh}>
+                            <Icon name="refresh" size={16} color={colors.primary} />
+                            <Text style={styles.refreshButtonText}>{refreshLabel}</Text>
+                        </TouchableOpacity>
+                    </View>
+
+                    {hasProcessingImports ? (
+                        <View style={styles.processingBadge}>
+                            <Icon name="clock-o" size={14} color="#B45309" />
+                            <Text style={styles.processingBadgeText}>{processingLabel}</Text>
+                        </View>
+                    ) : null}
                 </View>
 
                 <View style={styles.searchRow}>
@@ -256,8 +417,8 @@ const Imports = ({ context = {}, onClose }) => {
                 onClose={() => setShowAddImportModal(false)}
                 context={context}
                 onSuccess={() => {
-                    fetchImports(searchQuery, 1);
                     setCurrentPage(1);
+                    fetchImports(searchQuery, 1);
                 }}
             />
         </View>

--- a/src/react/pages/Imports.styles.js
+++ b/src/react/pages/Imports.styles.js
@@ -27,10 +27,13 @@ const styles = StyleSheet.create({
   },
 
   topRow: {
+    marginBottom: 8,
+  },
+
+  topRowActions: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 8,
+    flexWrap: 'wrap',
   },
 
   downloadButton: {
@@ -43,6 +46,38 @@ const styles = StyleSheet.create({
   },
 
   downloadText: { color: '#fff', fontWeight: '600', marginLeft: 6 },
+  refreshButton: {
+    marginLeft: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#EFF6FF',
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+  },
+  refreshButtonText: {
+    color: colors.primary,
+    fontWeight: '600',
+    marginLeft: 6,
+  },
+  processingBadge: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FEF3C7',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    marginTop: 10,
+  },
+  processingBadgeText: {
+    marginLeft: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#B45309',
+  },
   searchRow: { flexDirection: 'row', alignItems: 'center' },
 
   searchInputContainer: {
@@ -132,6 +167,32 @@ const styles = StyleSheet.create({
   infoText: {
     fontSize: 14,
     color: '#475569',
+    marginLeft: 8,
+    fontWeight: '500',
+    flex: 1,
+  },
+  statusContent: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  statusBadge: {
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  statusBadgeText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  statusHelperText: {
+    marginTop: 6,
+    fontSize: 12,
+    color: '#92400E',
+  },
+  errorText: {
+    fontSize: 13,
+    color: '#B91C1C',
     marginLeft: 8,
     fontWeight: '500',
     flex: 1,

--- a/src/react/utils/importStatus.js
+++ b/src/react/utils/importStatus.js
@@ -1,0 +1,100 @@
+const PROCESSING_IMPORT_STATUSES = ['pending', 'processing', 'queued', 'uploading', 'uploaded']
+const ERROR_IMPORT_STATUSES = ['error', 'failed', 'failure', 'invalid']
+const SUCCESS_IMPORT_STATUSES = ['done', 'success', 'completed', 'processed', 'finished']
+
+function normalizeImportStatus(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+}
+
+function getImportStatusMeta(item) {
+  const rawStatus =
+    item?.status?.realStatus ||
+    item?.status?.status ||
+    item?.status?.name ||
+    ''
+  const normalizedStatus = normalizeImportStatus(rawStatus)
+
+  if (PROCESSING_IMPORT_STATUSES.includes(normalizedStatus)) {
+    return {
+      isProcessing: true,
+      isError: false,
+      labelKey: 'processing',
+      rawStatus,
+      backgroundColor: '#FEF3C7',
+      textColor: '#B45309',
+    }
+  }
+
+  if (ERROR_IMPORT_STATUSES.includes(normalizedStatus)) {
+    return {
+      isProcessing: false,
+      isError: true,
+      labelKey: 'error',
+      rawStatus,
+      backgroundColor: '#FEE2E2',
+      textColor: '#B91C1C',
+    }
+  }
+
+  if (SUCCESS_IMPORT_STATUSES.includes(normalizedStatus)) {
+    return {
+      isProcessing: false,
+      isError: false,
+      labelKey: 'done',
+      rawStatus,
+      backgroundColor: '#DCFCE7',
+      textColor: '#15803D',
+    }
+  }
+
+  return {
+    isProcessing: false,
+    isError: false,
+    labelKey: 'fallback',
+    rawStatus,
+    backgroundColor: '#E2E8F0',
+    textColor: '#475569',
+  }
+}
+
+function getImportErrorDetail(item) {
+  const candidates = [
+    item?.error,
+    item?.errorMessage,
+    item?.status?.message,
+    item?.status?.description,
+    item?.status?.detail,
+    item?.detail,
+    item?.message,
+  ]
+
+  return candidates.find(candidate => String(candidate || '').trim()) || ''
+}
+
+function resolveImportLabels(translate) {
+  return {
+    refreshLabel: translate?.('imports', 'button', 'refresh'),
+    processingLabel: translate?.('imports', 'status', 'processing'),
+    errorLabel: translate?.('imports', 'status', 'error'),
+    doneLabel: translate?.('imports', 'status', 'done'),
+    noStatusLabel: translate?.('imports', 'status', 'no_status'),
+    processingHelpLabel: translate?.('imports', 'message', 'processing_after_upload'),
+  }
+}
+
+function resolveImportStatusLabel(statusMeta, labels = {}) {
+  if (statusMeta?.labelKey === 'processing') return labels.processingLabel
+  if (statusMeta?.labelKey === 'error') return labels.errorLabel
+  if (statusMeta?.labelKey === 'done') return labels.doneLabel
+  return statusMeta?.rawStatus || labels.noStatusLabel
+}
+
+module.exports = {
+  getImportErrorDetail,
+  getImportStatusMeta,
+  normalizeImportStatus,
+  resolveImportLabels,
+  resolveImportStatusLabel,
+}

--- a/src/tests/react/utils/importStatus.test.js
+++ b/src/tests/react/utils/importStatus.test.js
@@ -1,0 +1,85 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  getImportErrorDetail,
+  getImportStatusMeta,
+  normalizeImportStatus,
+  resolveImportLabels,
+  resolveImportStatusLabel,
+} = require('../../../react/utils/importStatus')
+
+test('normalizeImportStatus trims and lowercases the raw value', () => {
+  assert.equal(normalizeImportStatus('  Processing '), 'processing')
+})
+
+test('getImportStatusMeta keeps queued imports flagged as processing', () => {
+  const result = getImportStatusMeta({
+    status: {
+      status: 'queued',
+    },
+  })
+
+  assert.equal(result.isProcessing, true)
+  assert.equal(result.isError, false)
+  assert.equal(result.labelKey, 'processing')
+})
+
+test('getImportStatusMeta treats invalid imports as errors', () => {
+  const result = getImportStatusMeta({
+    status: {
+      realStatus: 'invalid',
+    },
+  })
+
+  assert.equal(result.isProcessing, false)
+  assert.equal(result.isError, true)
+  assert.equal(result.labelKey, 'error')
+})
+
+test('getImportErrorDetail returns the first non-empty message candidate', () => {
+  assert.equal(
+    getImportErrorDetail({
+      error: '  ',
+      status: {
+        description: 'Arquivo fora do padrão',
+      },
+      message: 'Mensagem menos específica',
+    }),
+    'Arquivo fora do padrão',
+  )
+})
+
+test('resolveImportLabels only reads translation keys without hardcoded fallbacks', () => {
+  const calls = []
+  const labels = resolveImportLabels((...args) => {
+    calls.push(args)
+    return args.join('.')
+  })
+
+  assert.deepEqual(calls, [
+    ['imports', 'button', 'refresh'],
+    ['imports', 'status', 'processing'],
+    ['imports', 'status', 'error'],
+    ['imports', 'status', 'done'],
+    ['imports', 'status', 'no_status'],
+    ['imports', 'message', 'processing_after_upload'],
+  ])
+  assert.equal(labels.refreshLabel, 'imports.button.refresh')
+  assert.equal(labels.processingHelpLabel, 'imports.message.processing_after_upload')
+})
+
+test('resolveImportStatusLabel falls back to the raw backend status before the generic empty label', () => {
+  assert.equal(
+    resolveImportStatusLabel(
+      {
+        labelKey: 'fallback',
+        rawStatus: 'sincronizando',
+      },
+      {
+        noStatusLabel: 'sem status',
+      },
+    ),
+    'sincronizando',
+  )
+})

--- a/src/tests/react/utils/importStatus.test.js
+++ b/src/tests/react/utils/importStatus.test.js
@@ -7,7 +7,7 @@ const {
   normalizeImportStatus,
   resolveImportLabels,
   resolveImportStatusLabel,
-} = require('../../../react/utils/importStatus')
+} = require('@controleonline/ui-common/src/react/utils/importStatus')
 
 test('normalizeImportStatus trims and lowercases the raw value', () => {
   assert.equal(normalizeImportStatus('  Processing '), 'processing')


### PR DESCRIPTION
## Summary
- keep the shared import list improvements for visible processing state, manual refresh and automatic polling while imports are pending
- move import status and label resolution into a dedicated helper so the screen reads translation keys without hardcoded fallback copy
- align the new helper imports with the repository alias convention instead of the relative paths flagged by QA
- add focused automated coverage for the import status helper and a pull-request workflow that runs this validation on review branches

## Issues
- relates to ControleOnline/app-community#78
- supports ControleOnline/app-community#75

## Validation
- `npm run test:imports-status`
- `git diff --check`
- GitHub Actions: `Pull Request Checks`

## Note
- this repository does not expose a `dev` branch; the PR targets `master` to keep the diff isolated and reviewable