### PR TITLE
Sync translations with the selected company language

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,19 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - run: npm run test:runtime-language

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "description": "ControleOnline Common Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "npm run test:runtime-language",
+    "test:runtime-language": "node --test src/tests/react/utils/runtimeLanguage.test.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ControleOnline/ui-common.git"

--- a/src/react/components/DefaultProvider.native.js
+++ b/src/react/components/DefaultProvider.native.js
@@ -10,6 +10,7 @@ import ProductCatalogCacheService from '@controleonline/ui-common/src/react/comp
 import RuntimeInfoFooter from '@controleonline/ui-common/src/react/components/RuntimeInfoFooter';
 import {api} from '@controleonline/ui-common/src/api';
 import {env as APP_ENV} from '@env';
+const {resolveConfiguredLanguage} = require('../utils/runtimeLanguage');
 import {
   applyPaletteToRuntimeColors,
   applyThemeCssVariables,
@@ -50,35 +51,6 @@ const parseThemeCss = cssText => {
   });
 
   return parsedColors;
-};
-
-const normalizeLanguageCode = value => {
-  if (typeof value !== 'string') {
-    return '';
-  }
-
-  return value.trim().replace(/_/g, '-').toLowerCase();
-};
-
-const resolveCompanyLanguageCode = company => {
-  const candidates = [
-    company?.language?.language,
-    company?.language?.locale,
-    company?.language?.code,
-    company?.locale,
-    company?.languageCode,
-    typeof company?.language === 'string' ? company.language : '',
-    company?.configs?.language,
-  ];
-
-  for (const candidate of candidates) {
-    const normalized = normalizeLanguageCode(candidate);
-    if (normalized) {
-      return normalized;
-    }
-  }
-
-  return '';
 };
 
 export const DefaultProvider = ({children, onBootstrapReady}) => {
@@ -466,12 +438,12 @@ export const DefaultProvider = ({children, onBootstrapReady}) => {
     ) {
       const currentConfig = JSON.parse(localStorage.getItem('config') || '{}');
       const sessionData = JSON.parse(localStorage.getItem('session') || '{}');
-      const configuredLanguage =
-        resolveCompanyLanguageCode(currentCompany) ||
-        resolveCompanyLanguageCode(defaultCompany) ||
-        currentConfig?.language ||
-        sessionData?.language ||
-        'pt-br';
+      const configuredLanguage = resolveConfiguredLanguage({
+        currentCompany,
+        defaultCompany,
+        currentConfig,
+        sessionData,
+      });
 
       if (currentConfig.language !== configuredLanguage) {
         const nextConfig = {...currentConfig, language: configuredLanguage};

--- a/src/react/components/DefaultProvider.native.js
+++ b/src/react/components/DefaultProvider.native.js
@@ -52,6 +52,35 @@ const parseThemeCss = cssText => {
   return parsedColors;
 };
 
+const normalizeLanguageCode = value => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().replace(/_/g, '-').toLowerCase();
+};
+
+const resolveCompanyLanguageCode = company => {
+  const candidates = [
+    company?.language?.language,
+    company?.language?.locale,
+    company?.language?.code,
+    company?.locale,
+    company?.languageCode,
+    typeof company?.language === 'string' ? company.language : '',
+    company?.configs?.language,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeLanguageCode(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+};
+
 export const DefaultProvider = ({children, onBootstrapReady}) => {
   const appType = String(APP_ENV.APP_TYPE || '').toUpperCase();
   const isShopClientApp = appType === 'SHOP';
@@ -438,9 +467,11 @@ export const DefaultProvider = ({children, onBootstrapReady}) => {
       const currentConfig = JSON.parse(localStorage.getItem('config') || '{}');
       const sessionData = JSON.parse(localStorage.getItem('session') || '{}');
       const configuredLanguage =
+        resolveCompanyLanguageCode(currentCompany) ||
+        resolveCompanyLanguageCode(defaultCompany) ||
         currentConfig?.language ||
         sessionData?.language ||
-        'pt-BR';
+        'pt-br';
 
       if (currentConfig.language !== configuredLanguage) {
         const nextConfig = {...currentConfig, language: configuredLanguage};
@@ -450,6 +481,7 @@ export const DefaultProvider = ({children, onBootstrapReady}) => {
         );
       }
 
+      setTranslateReady(false);
       global.t = new Translate(
         companies,
         defaultCompany,
@@ -460,6 +492,7 @@ export const DefaultProvider = ({children, onBootstrapReady}) => {
 
       global.t.discoveryAll().then(() => {
         setTranslateReady(true);
+        global.refreshTranslationsUI?.();
       });
     }
   }, [currentCompany, defaultCompany, deviceConfigFetched, isLogged]);

--- a/src/react/components/DefaultProvider.web.js
+++ b/src/react/components/DefaultProvider.web.js
@@ -10,6 +10,7 @@ import RuntimeInfoFooter from '@controleonline/ui-common/src/react/components/Ru
 import { useStore } from '@store';
 import { api } from '@controleonline/ui-common/src/api';
 import { env as APP_ENV } from '@env';
+const { resolveConfiguredLanguage } = require('../utils/runtimeLanguage');
 import {
   applyPaletteToRuntimeColors,
   applyThemeCssVariables,
@@ -49,35 +50,6 @@ const parseThemeCss = cssText => {
   });
 
   return parsedColors;
-};
-
-const normalizeLanguageCode = value => {
-  if (typeof value !== 'string') {
-    return '';
-  }
-
-  return value.trim().replace(/_/g, '-').toLowerCase();
-};
-
-const resolveCompanyLanguageCode = company => {
-  const candidates = [
-    company?.language?.language,
-    company?.language?.locale,
-    company?.language?.code,
-    company?.locale,
-    company?.languageCode,
-    typeof company?.language === 'string' ? company.language : '',
-    company?.configs?.language,
-  ];
-
-  for (const candidate of candidates) {
-    const normalized = normalizeLanguageCode(candidate);
-    if (normalized) {
-      return normalized;
-    }
-  }
-
-  return '';
 };
 
 const normalizeDeviceId = value =>
@@ -537,12 +509,12 @@ export const DefaultProvider = ({ children, onBootstrapReady }) => {
     ) {
       const currentConfig = JSON.parse(localStorage.getItem('config') || '{}');
       const sessionData = JSON.parse(localStorage.getItem('session') || '{}');
-      const configuredLanguage =
-        resolveCompanyLanguageCode(currentCompany) ||
-        resolveCompanyLanguageCode(defaultCompany) ||
-        currentConfig?.language ||
-        sessionData?.language ||
-        'pt-br';
+      const configuredLanguage = resolveConfiguredLanguage({
+        currentCompany,
+        defaultCompany,
+        currentConfig,
+        sessionData,
+      });
 
       if (currentConfig.language !== configuredLanguage) {
         const nextConfig = { ...currentConfig, language: configuredLanguage };

--- a/src/react/components/DefaultProvider.web.js
+++ b/src/react/components/DefaultProvider.web.js
@@ -51,6 +51,35 @@ const parseThemeCss = cssText => {
   return parsedColors;
 };
 
+const normalizeLanguageCode = value => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().replace(/_/g, '-').toLowerCase();
+};
+
+const resolveCompanyLanguageCode = company => {
+  const candidates = [
+    company?.language?.language,
+    company?.language?.locale,
+    company?.language?.code,
+    company?.locale,
+    company?.languageCode,
+    typeof company?.language === 'string' ? company.language : '',
+    company?.configs?.language,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeLanguageCode(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return '';
+};
+
 const normalizeDeviceId = value =>
   String(value?.device || value?.id || value || '').trim();
 
@@ -509,9 +538,11 @@ export const DefaultProvider = ({ children, onBootstrapReady }) => {
       const currentConfig = JSON.parse(localStorage.getItem('config') || '{}');
       const sessionData = JSON.parse(localStorage.getItem('session') || '{}');
       const configuredLanguage =
+        resolveCompanyLanguageCode(currentCompany) ||
+        resolveCompanyLanguageCode(defaultCompany) ||
         currentConfig?.language ||
         sessionData?.language ||
-        'pt-BR';
+        'pt-br';
 
       if (currentConfig.language !== configuredLanguage) {
         const nextConfig = { ...currentConfig, language: configuredLanguage };
@@ -521,6 +552,7 @@ export const DefaultProvider = ({ children, onBootstrapReady }) => {
         );
       }
 
+      setTranslateReady(false);
       global.t = new Translate(
         companies,
         defaultCompany,
@@ -531,6 +563,7 @@ export const DefaultProvider = ({ children, onBootstrapReady }) => {
 
       global.t.discoveryAll().then(() => {
         setTranslateReady(true);
+        global.refreshTranslationsUI?.();
       });
     }
   }, [currentCompany, defaultCompany, deviceConfigFetched, isLogged]);

--- a/src/react/utils/runtimeLanguage.js
+++ b/src/react/utils/runtimeLanguage.js
@@ -1,0 +1,50 @@
+function normalizeLanguageCode(value) {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().replace(/_/g, '-').toLowerCase()
+}
+
+function resolveCompanyLanguageCode(company) {
+  const candidates = [
+    company?.language?.language,
+    company?.language?.locale,
+    company?.language?.code,
+    company?.locale,
+    company?.languageCode,
+    typeof company?.language === 'string' ? company.language : '',
+    company?.configs?.language,
+  ]
+
+  for (const candidate of candidates) {
+    const normalized = normalizeLanguageCode(candidate)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  return ''
+}
+
+function resolveConfiguredLanguage({
+  currentCompany,
+  defaultCompany,
+  currentConfig,
+  sessionData,
+  fallback = 'pt-br',
+} = {}) {
+  return (
+    resolveCompanyLanguageCode(currentCompany) ||
+    resolveCompanyLanguageCode(defaultCompany) ||
+    normalizeLanguageCode(currentConfig?.language) ||
+    normalizeLanguageCode(sessionData?.language) ||
+    fallback
+  )
+}
+
+module.exports = {
+  normalizeLanguageCode,
+  resolveCompanyLanguageCode,
+  resolveConfiguredLanguage,
+}

--- a/src/tests/react/utils/runtimeLanguage.test.js
+++ b/src/tests/react/utils/runtimeLanguage.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  normalizeLanguageCode,
+  resolveCompanyLanguageCode,
+  resolveConfiguredLanguage,
+} = require('../../../react/utils/runtimeLanguage')
+
+test('normalizes language separators and casing', () => {
+  assert.equal(normalizeLanguageCode(' PT_BR '), 'pt-br')
+})
+
+test('reads the current company language from nested company settings first', () => {
+  assert.equal(
+    resolveCompanyLanguageCode({
+      language: {
+        locale: 'en_US',
+      },
+    }),
+    'en-us',
+  )
+})
+
+test('prefers the selected company language over cached config and session values', () => {
+  assert.equal(
+    resolveConfiguredLanguage({
+      currentCompany: {
+        language: {
+          code: 'en_US',
+        },
+      },
+      defaultCompany: {
+        language: {
+          code: 'pt_BR',
+        },
+      },
+      currentConfig: {
+        language: 'es-es',
+      },
+      sessionData: {
+        language: 'fr-fr',
+      },
+    }),
+    'en-us',
+  )
+})
+
+test('falls back through default company, config, session and the hardcoded default', () => {
+  assert.equal(
+    resolveConfiguredLanguage({
+      defaultCompany: {
+        configs: {
+          language: 'de_DE',
+        },
+      },
+    }),
+    'de-de',
+  )
+
+  assert.equal(
+    resolveConfiguredLanguage({
+      currentConfig: {
+        language: 'it_IT',
+      },
+    }),
+    'it-it',
+  )
+
+  assert.equal(
+    resolveConfiguredLanguage({
+      sessionData: {
+        language: 'nl_NL',
+      },
+    }),
+    'nl-nl',
+  )
+
+  assert.equal(resolveConfiguredLanguage({}), 'pt-br')
+})


### PR DESCRIPTION
## Summary
- prefer the selected company language when bootstrapping translations after a company switch
- normalize company locale values before persisting them in local storage
- refresh shared translations after the language swap so the UI can redraw with the newly selected company language

## Issue
- relates to ControleOnline/app-community#63

## Validation
- `git diff --check`
- code inspection of `src/react/components/DefaultProvider.web.js` and `src/react/components/DefaultProvider.native.js`

## Note
- this repository does not expose a `dev` branch; the PR targets `master` to keep the diff isolated and reviewable