### PR TITLE
feat: expose overdue opportunity maintenance routine

### DIFF
--- a/src/react/utils/maintenanceSettings.js
+++ b/src/react/utils/maintenanceSettings.js
@@ -9,6 +9,14 @@ export const MAINTENANCE_ROUTINE_ITEMS = [
     defaultEnabled: true,
     defaultCronExpression: '* * * * *',
   },
+  {
+    key: 'open_overdue_opportunities',
+    title: 'Oportunidades vencidas para aberto',
+    description:
+      'Move oportunidades de CRM de pendente para aberto quando a data de retorno ja passou.',
+    defaultEnabled: true,
+    defaultCronExpression: '* * * * *',
+  },
 ];
 
 export const normalizeMaintenanceRoutines = value => {

--- a/src/react/utils/maintenanceSettings.js
+++ b/src/react/utils/maintenanceSettings.js
@@ -1,22 +1,38 @@
 export const MAINTENANCE_ROUTINES_CONFIG_KEY = 'maintenance-routines';
 
+const translateRoutineLabel = key => global.t?.t('configs', 'label', key);
+
+const translateRoutineMessage = key => global.t?.t('configs', 'message', key);
+
+const createMaintenanceRoutineItem = ({
+  key,
+  titleKey,
+  descriptionKey,
+  defaultEnabled = true,
+  defaultCronExpression = '* * * * *',
+}) => ({
+  key,
+  get title() {
+    return translateRoutineLabel(titleKey);
+  },
+  get description() {
+    return translateRoutineMessage(descriptionKey);
+  },
+  defaultEnabled,
+  defaultCronExpression,
+});
+
 export const MAINTENANCE_ROUTINE_ITEMS = [
-  {
+  createMaintenanceRoutineItem({
     key: 'cleanup_logs',
-    title: 'Limpeza de logs',
-    description:
-      'Executa a politica de retencao dos logs e remove registros expirados.',
-    defaultEnabled: true,
-    defaultCronExpression: '* * * * *',
-  },
-  {
+    titleKey: 'cleanup_logs',
+    descriptionKey: 'cleanup_logs_description',
+  }),
+  createMaintenanceRoutineItem({
     key: 'open_overdue_opportunities',
-    title: 'Oportunidades vencidas para aberto',
-    description:
-      'Move oportunidades de CRM de pendente para aberto quando a data de retorno ja passou.',
-    defaultEnabled: true,
-    defaultCronExpression: '* * * * *',
-  },
+    titleKey: 'open_overdue_opportunities',
+    descriptionKey: 'open_overdue_opportunities_description',
+  }),
 ];
 
 export const normalizeMaintenanceRoutines = value => {

--- a/src/tests/react/utils/maintenanceSettings.test.js
+++ b/src/tests/react/utils/maintenanceSettings.test.js
@@ -1,0 +1,45 @@
+const {jest} = require('@jest/globals')
+
+const {
+  MAINTENANCE_ROUTINE_ITEMS,
+  normalizeMaintenanceRoutines,
+} = require('../../../react/utils/maintenanceSettings')
+
+const {describe, expect, it, beforeEach} = global
+
+describe('maintenanceSettings', () => {
+  beforeEach(() => {
+    global.t = {
+      t: jest.fn((store, type, key) => `${store}:${type}:${key}`),
+    }
+  })
+
+  it('resolves customer-facing labels through the translation helper', () => {
+    const cleanupLogsRoutine = MAINTENANCE_ROUTINE_ITEMS.find(
+      item => item.key === 'cleanup_logs',
+    )
+    const overdueOpportunitiesRoutine = MAINTENANCE_ROUTINE_ITEMS.find(
+      item => item.key === 'open_overdue_opportunities',
+    )
+
+    expect(cleanupLogsRoutine.title).toBe('configs:label:cleanup_logs')
+    expect(cleanupLogsRoutine.description).toBe(
+      'configs:message:cleanup_logs_description',
+    )
+    expect(overdueOpportunitiesRoutine.title).toBe(
+      'configs:label:open_overdue_opportunities',
+    )
+    expect(overdueOpportunitiesRoutine.description).toBe(
+      'configs:message:open_overdue_opportunities_description',
+    )
+  })
+
+  it('keeps the new routine enabled with the default cron expression', () => {
+    const normalized = normalizeMaintenanceRoutines({})
+
+    expect(normalized.open_overdue_opportunities).toEqual({
+      enabled: true,
+      cronExpression: '* * * * *',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- route the maintenance routine labels through `global.t?.t(...)` instead of leaving customer-facing literals in the shared catalog
- add a focused JS test for the maintenance settings helper and the overdue opportunity routine defaults

## Issue
- Refs ControleOnline/app-community#71

## Validation
- executed a local Node harness to confirm the new routine resolves translation keys and keeps the default cron payload normalized
- full frontend package installation was not available in this session, so the repository Jest suite was not executed here