### PR TITLE
task-104: refine shared Portuguese copy

### DIFF
--- a/src/react/components/EntityLogContent.js
+++ b/src/react/components/EntityLogContent.js
@@ -98,7 +98,7 @@ const formatContextValue = value => {
   }
 
   if (typeof value === 'boolean') {
-    return value ? 'Sim' : 'Nao';
+    return value ? 'Sim' : 'Não';
   }
 
   if (typeof value === 'string') {
@@ -205,7 +205,7 @@ const EntitySummaryCard = ({
 
       {detailState?.status === 'error' ? (
         <Text style={styles.entityStateErrorText}>
-          {detailState?.error || 'Nao foi possivel carregar os detalhes.'}
+          {detailState?.error || 'Não foi possível carregar os detalhes.'}
         </Text>
       ) : null}
     </View>
@@ -668,14 +668,14 @@ const EntityLogBranch = ({
           {logsState.status === 'loading' ? (
             <View style={styles.stateBox}>
               <ActivityIndicator size="small" color="#2563EB" />
-              <Text style={styles.stateText}>Carregando historico...</Text>
+              <Text style={styles.stateText}>Carregando histórico...</Text>
             </View>
           ) : null}
 
           {logsState.status === 'error' ? (
             <View style={styles.stateBox}>
               <Icon name="error-outline" size={20} color="#DC2626" />
-              <Text style={styles.stateTitle}>Nao foi possivel carregar</Text>
+              <Text style={styles.stateTitle}>Não foi possível carregar</Text>
               <Text style={styles.stateText}>{logsState.error || 'Erro desconhecido'}</Text>
             </View>
           ) : null}
@@ -685,7 +685,7 @@ const EntityLogBranch = ({
               <Icon name="history-toggle-off" size={22} color="#94A3B8" />
               <Text style={styles.stateTitle}>Nenhum log encontrado</Text>
               <Text style={styles.stateText}>
-                Ainda nao existem registros para esta entidade.
+                Ainda não existem registros para esta entidade.
               </Text>
             </View>
           ) : null}

--- a/src/react/components/LinkedOrderProductsTab.js
+++ b/src/react/components/LinkedOrderProductsTab.js
@@ -25,7 +25,7 @@ import {
 import styles from './LinkedOrderProductsTab.styles';
 
 const formatApiError = error => {
-  if (!error) return 'Nao foi possivel concluir a operacao.';
+  if (!error) return 'Não foi possível concluir a operação.';
   if (typeof error === 'string') return error;
   if (Array.isArray(error?.message)) {
     return error.message
@@ -34,7 +34,7 @@ const formatApiError = error => {
       .join('\n');
   }
 
-  return error?.message || error?.description || error?.errmsg || 'Nao foi possivel concluir a operacao.';
+  return error?.message || error?.description || error?.errmsg || 'Não foi possível concluir a operação.';
 };
 
 const resolveProductLabel = orderProduct => {
@@ -60,7 +60,7 @@ const LinkedOrderProductsTab = ({
   contract,
   canEdit,
   emptyTitle = 'Nenhum produto adicionado.',
-  emptySubtitle = 'Voce pode vincular produtos a este documento quando precisar.',
+  emptySubtitle = 'Você pode vincular produtos a este documento quando precisar.',
   searchPlaceholder = 'Buscar produto para adicionar...',
 }) => {
   const peopleStore = useStore('people');

--- a/src/react/components/RemoteCheckoutService.js
+++ b/src/react/components/RemoteCheckoutService.js
@@ -123,7 +123,7 @@ const Checkout = () => {
 
     if (!paidStatusIri) {
       invoiceActions.setError(
-        'Nao foi possivel resolver o status pago da invoice do PDV.',
+        'Não foi possível resolver o status pago da invoice do PDV.',
       );
       return;
     }
@@ -258,7 +258,7 @@ const Checkout = () => {
       } catch (error) {
         const errorMessage = normalizeGatewayPaymentError(
           error,
-          'Nao foi possivel concluir o pagamento remoto.',
+          'Não foi possível concluir o pagamento remoto.',
         );
         invoiceActions.setError(errorMessage);
         await sendRemoteResult({

--- a/src/react/pages/EntityLogPage.js
+++ b/src/react/pages/EntityLogPage.js
@@ -86,7 +86,7 @@ export default function EntityLogPage({navigation, route}) {
 
   useEffect(() => {
     navigation.setOptions({
-      title: 'Historico',
+      title: 'Histórico',
     });
   }, [navigation]);
 

--- a/src/react/pages/GenericLogPage.js
+++ b/src/react/pages/GenericLogPage.js
@@ -142,7 +142,7 @@ const formatValue = value => {
   }
 
   if (typeof value === 'boolean') {
-    return value ? 'Sim' : 'Nao';
+    return value ? 'Sim' : 'Não';
   }
 
   if (typeof value === 'string') {
@@ -706,7 +706,7 @@ export default function GenericLogPage({navigation}) {
           {logsState.status === 'error' ? (
             <View style={styles.stateBox}>
               <Icon name="error-outline" size={22} color="#DC2626" />
-              <Text style={styles.stateTitle}>Nao foi possivel carregar</Text>
+              <Text style={styles.stateTitle}>Não foi possível carregar</Text>
               <Text style={styles.stateText}>{logsState.error}</Text>
             </View>
           ) : null}

--- a/src/react/router/routes.js
+++ b/src/react/router/routes.js
@@ -9,7 +9,7 @@ const commonRoutes = [
     options: {
       headerShown: true,
       headerBackVisible: true,
-      title: 'Historico',
+      title: 'Histórico',
     },
   },
   {

--- a/src/react/utils/logSettings.js
+++ b/src/react/utils/logSettings.js
@@ -11,27 +11,27 @@ export const LOG_POLICY_ITEMS = [
   },
   {
     key: 'entity',
-    title: 'Historico de entidades',
+    title: 'Histórico de entidades',
     description:
-      'Mantem os diffs de criacao, alteracao e remocao das entidades do sistema.',
+      'Mantém os diffs de criação, alteração e remoção das entidades do sistema.',
   },
   {
     key: 'generic',
-    title: 'Logs genericos',
+    title: 'Logs genéricos',
     description:
-      'Agrupa logs tecnicos de integracao, workers e eventos que nao sao timeline de entidade.',
+      'Agrupa logs técnicos de integração, workers e eventos que não são timeline de entidade.',
   },
   {
     key: 'operation_patterns',
-    title: 'Padroes operacionais',
+    title: 'Padrões operacionais',
     description:
-      'Mantem registros tecnicos ligados a padroes e diagnosticos operacionais do sistema.',
+      'Mantém registros técnicos ligados a padrões e diagnósticos operacionais do sistema.',
   },
   {
     key: 'frontend_debug',
     title: 'Debug do front-end',
     description:
-      'Recebe logs enviados pelo React para apoio de debug e investigacao remota.',
+      'Recebe logs enviados pelo React para apoio de debug e investigação remota.',
   },
 ];
 


### PR DESCRIPTION
Refs ControleOnline/app-community#104

## Summary
- fix Portuguese accents in history/log screens and labels
- polish generic operation and remote checkout error copy
- improve shared wording in log policy settings

## Validation
- `git diff --check`
- automated tests not run in this session because the change is limited to user-facing copy