### PR TITLE
fix: normalize API fetch failures before bubbling to the UI

### DIFF
--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,37 +1,78 @@
 import { APP_ENV } from "../../../../../config/env.js";
 
+function buildHttpError(response, payload, fallbackMessage) {
+  const message =
+    payload?.description ||
+    payload?.message ||
+    payload?.error ||
+    fallbackMessage ||
+    response.statusText ||
+    `HTTP ${response.status}`;
+
+  return {
+    message,
+    code: response.status,
+    status: response.status,
+    payload,
+  };
+}
+
+function parseJsonSafely(text) {
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+}
+
 export default function (resourceEndpoint, options = {}) {
   const entryPoint =
     APP_ENV.API_ENTRYPOINT + (APP_ENV.API_ENTRYPOINT.endsWith("/") ? "" : "/");
 
   if (!resourceEndpoint || !entryPoint) return;
 
-  // if (resourceEndpoint == "/people/companies/my")
-  //console.log(entryPoint, resourceEndpoint, options);
-
-  //console.log(entryPoint, resourceEndpoint);
-
   return fetch(new URL(resourceEndpoint, entryPoint), options).then(
-    (response) => {
-
+    async (response) => {
       if (options.method == "DELETE") return;
-      if (options.responseType == "text") return response.text();
 
-      return response.json().then((json) => {
-        if (json["@type"] == "Error")
-          throw {
-            message: json["description"],
-            code: response.status,
-            status: response.status,
-          };
-        if (json["@type"] == "ConstraintViolationList")
-          throw {
-            message: json["violations"],
-            code: response.status,
-            status: response.status,
-          };
+      const responseText = await response.text();
+      const json = parseJsonSafely(responseText);
+
+      if (options.responseType == "text") {
+        if (!response.ok) {
+          throw buildHttpError(response, json, responseText);
+        }
+
+        return responseText;
+      }
+
+      if (!response.ok) {
+        throw buildHttpError(response, json, responseText);
+      }
+
+      if (json?.["@type"] == "Error") {
+        throw buildHttpError(response, json, json["description"]);
+      }
+
+      if (json?.["@type"] == "ConstraintViolationList") {
+        throw buildHttpError(response, json, json["violations"]);
+      }
+
+      if (json !== null) {
         return json;
-      });
+      }
+
+      if (!responseText) {
+        return null;
+      }
+
+      throw buildHttpError(
+        response,
+        null,
+        "Invalid JSON response received from API",
+      );
     }
   );
 }


### PR DESCRIPTION
## Summary
- normalize HTTP failures before they reach the UI promise chain
- stop assuming every non-text response body is valid JSON
- preserve backend status and payload details in a predictable error object

## Why
A production screenshot showed multiple API `500`/`404` responses followed by `Unhandled Promise Rejection: [object Object]`. The API failures still need backend investigation, but the common fetch layer should not crash the UI or mask the original status when the response body is empty, plain text, or invalid JSON.

## Validation
- logic reviewed against the current fetch wrapper flow
- not runtime-tested in this automation session because the app and private environment are not reachable from here
