### PR TITLE
fix: prevent CSV import modal crash for issue #105

### DIFF
--- a/src/react/pages/Imports.js
+++ b/src/react/pages/Imports.js
@@ -26,13 +26,12 @@ const {
 
 const formatDate = (dateString) => {
     const d = new Date(dateString);
-    return d.toLocaleString(); // Formato local legível
+    return d.toLocaleString();
 };
 
 const Imports = ({ context = {}, onClose }) => {
     const peopleStore = useStore('people');
-    const { getters: peopleGetters } = peopleStore.getters;
-    const { currentCompany } = peopleGetters;
+    const { currentCompany } = peopleStore.getters;
 
     const importType = context.context;
     const title = context.title;
@@ -44,7 +43,7 @@ const Imports = ({ context = {}, onClose }) => {
         doneLabel,
         noStatusLabel,
         processingHelpLabel,
-    } = resolveImportLabels(global.t?.t);
+    } = resolveImportLabels(global.t ? (...args) => global.t.t(...args) : undefined);
 
     const navigation = useNavigation();
 
@@ -241,7 +240,6 @@ const Imports = ({ context = {}, onClose }) => {
 
             if (!csvText) throw new Error('CSV vazio');
 
-            // mobile: verifica se o diretório está disponível
             const dirUri = Directory?.cacheDocumentDirectory || Directory?.documentDirectory;
 
             if (dirUri) {
@@ -257,7 +255,6 @@ const Imports = ({ context = {}, onClose }) => {
                 console.log(`Arquivo CSV criado em: ${fileUri}`);
                 return fileUri;
             } else if (typeof window !== 'undefined') {
-                // fallback web
                 const blob = new Blob([csvText], { type: 'text/csv' });
                 const link = document.createElement('a');
                 link.href = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- fix the `Imports` page crash when opening the CSV import modal
- preserve the translation service context before calling `resolveImportLabels`
- read `currentCompany` from `peopleStore.getters` using the same store contract already used by `AddImportModal`

## Root cause
- `global.t.t` was passed as an unbound method, so `Translate.t` ran without `this` and crashed while trying to call `getMessageFromBuckets`
- `peopleStore.getters.getters` did not match the shape used elsewhere in the shared import flow

## Validation
- read the current `ui-common` and `app-community` issue/PR state from GitHub before editing
- verified the branch diff against `master`
- reproduced the unbound-method failure and the wrapped-call success with a local Node validation snippet

## Follow-up
- `ControleOnline/app-community#105` still needs the submodule pointer update in `modules/controleonline/ui-common` so the app consumes this commit
- existing draft PR `ControleOnline/app-community#132` should be refreshed to point at this `ui-common` commit instead of the previous unreachable submodule SHA