### PR TITLE
task-75: mostrar erro real na importação de CSV

### DIFF
--- a/src/react/components/AddImportModal.js
+++ b/src/react/components/AddImportModal.js
@@ -14,6 +14,7 @@ import { useStore } from '@store';
 import AnimatedModal from '@controleonline/ui-crm/src/react/components/AnimatedModal';
 import { api } from '@controleonline/ui-common/src/api';
 import { useMessage } from '@controleonline/ui-common/src/react/components/MessageService';
+import { resolveSystemErrorMessage } from '@controleonline/ui-common/src/react/utils/systemErrorMessage';
 import styles from './AddImportModal.styles';
 
 const AddImportModal = ({ visible, onClose, onSuccess, context = {} }) => {
@@ -90,8 +91,10 @@ const AddImportModal = ({ visible, onClose, onSuccess, context = {} }) => {
             showSuccess(importSuccessLabel);
             if (onSuccess) onSuccess();
             handleClose();
-        } catch {
-            showError(importErrorLabel);
+        } catch (error) {
+            const importFeedback =
+                resolveSystemErrorMessage(error) || importErrorLabel;
+            showError(importFeedback);
         } finally {
             setLoading(false);
         }

--- a/src/react/utils/systemErrorMessage.js
+++ b/src/react/utils/systemErrorMessage.js
@@ -16,6 +16,28 @@ const resolveMessageList = items =>
     .trim()
 
 export const resolveSystemErrorMessage = error => {
+  const resolveNestedMessage = value => {
+    const nestedCandidates = [
+      value?.response?.data,
+      value?.data,
+      value?.response,
+      value?.cause,
+    ]
+
+    for (const candidate of nestedCandidates) {
+      if (!candidate || candidate === value) {
+        continue
+      }
+
+      const nestedMessage = resolveSystemErrorMessage(candidate)
+      if (nestedMessage) {
+        return nestedMessage
+      }
+    }
+
+    return ''
+  }
+
   if (error === undefined || error === null) {
     return ''
   }
@@ -36,9 +58,16 @@ export const resolveSystemErrorMessage = error => {
     return resolveMessageList(error.violations)
   }
 
+  const nestedMessage = resolveNestedMessage(error)
+  if (nestedMessage) {
+    return nestedMessage
+  }
+
   return normalizeText(
     error?.detail ||
       error?.description ||
+      error?.['hydra:description'] ||
+      error?.['hydra:title'] ||
       error?.errmsg ||
       error?.error ||
       error?.message ||

--- a/src/tests/react/utils/systemErrorMessage.test.js
+++ b/src/tests/react/utils/systemErrorMessage.test.js
@@ -33,4 +33,17 @@ describe('systemErrorMessage', () => {
       }),
     ).toBe('Primeiro erro\nSegundo erro')
   })
+
+  it('reads nested axios response payloads before the transport message', () => {
+    expect(
+      resolveSystemErrorMessage({
+        message: 'Request failed with status code 422',
+        response: {
+          data: {
+            'hydra:description': 'Arquivo com colunas invalidas.',
+          },
+        },
+      }),
+    ).toBe('Arquivo com colunas invalidas.')
+  })
 })


### PR DESCRIPTION
## Summary
- surface the backend upload error in the shared CSV import modal instead of collapsing everything into a generic failure toast
- teach the shared `resolveSystemErrorMessage` helper to read nested Axios payloads such as `error.response.data`
- add focused coverage for the nested response case so CSV import errors keep rendering the user-facing backend message

## Issue
- relates to ControleOnline/app-community#75

## Validation
- validated the new nested error resolution flow with a focused local Node harness covering Hydra and Axios-like payloads
- confirmed the change stays scoped to the shared import modal and error helper
- full repository test execution was not available in this session because the repository could not be cloned locally from this runtime

## Note
- `app-community` still needs the submodule pointer update in `modules/controleonline/ui-common` so the Manager products import flow consumes this fix